### PR TITLE
one more bugfix for close day

### DIFF
--- a/src/components/CloseDay.jsx
+++ b/src/components/CloseDay.jsx
@@ -476,6 +476,8 @@ const CloseDayPage = () => {
             setPostSuccess(false);
             toast.error(poss[currentPosIndex].name + " failed to close!");
           }
+
+          setShowConfirm(false);
         })
         .catch((error) => {
           toast.error(


### PR DESCRIPTION
- closing the safe should now properly hide the confirmation popup if we have a >2$ variance