### PR TITLE
adjusted openday input styling on very first open day

### DIFF
--- a/src/components/CloseDay.jsx
+++ b/src/components/CloseDay.jsx
@@ -785,7 +785,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={BillHundred}
-                        alt="100's"
+                        //alt="100's"
                         className="inline-block align-middle w-12 h-12"
                         alt="100 Dollar Bill"
                       />
@@ -814,7 +814,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={RollQuarter}
-                        alt="Quarter Rolls"
+                        //alt="Quarter Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Roll of Quarters"
                       />
@@ -847,7 +847,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={BillFifty}
-                        alt="50's"
+                        //alt="50's"
                         className="inline-block align-middle w-12 h-12"
                         alt="50 Dollar Bill"
                       />
@@ -876,7 +876,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={RollDime}
-                        alt="Dime Rolls"
+                        //alt="Dime Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Roll of Dimes"
                       />
@@ -907,7 +907,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={BillTwenty}
-                        alt="20's"
+                        //alt="20's"
                         className="inline-block align-middle w-12 h-12"
                         alt="20 Dollar Bill"
                       />
@@ -936,7 +936,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={RollNickel}
-                        alt="Nickel Rolls"
+                        //alt="Nickel Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Roll of Nickels"
                       />
@@ -969,7 +969,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={BillTen}
-                        alt="10's"
+                        //alt="10's"
                         className="inline-block align-middle w-12 h-12"
                         alt="10 Dollar Bill"
                       />
@@ -998,7 +998,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={RollPenny}
-                        alt="Penny Rolls"
+                        //alt="Penny Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Roll of Pennies"
                       />
@@ -1031,7 +1031,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={BillFive}
-                        alt="5's"
+                        //alt="5's"
                         className="inline-block align-middle w-12 h-12"
                         alt="5 Dollar Bill"
                       />
@@ -1060,7 +1060,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={CoinQuarter}
-                        alt="Quarters"
+                        //alt="Quarters"
                         className="inline-block align-middle w-12 h-12"
                         alt="Quarter Coin"
                       />
@@ -1091,7 +1091,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={BillOne}
-                        alt="1's"
+                        //alt="1's"
                         className="inline-block align-middle w-12 h-12"
                         alt="1 Dollar Bill"
                       />
@@ -1120,7 +1120,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={CoinDime}
-                        alt="Dimes"
+                        //alt="Dimes"
                         className="inline-block align-middle w-12 h-12"
                         alt="Dime Coin"
                       />
@@ -1164,7 +1164,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={CoinNickel}
-                        alt="Nickels"
+                        //alt="Nickels"
                         className="inline-block align-middle w-12 h-12"
                         alt="Nickel Coin"
                       />
@@ -1197,7 +1197,7 @@ const CloseDayPage = () => {
                         <label>
                           <img
                             src={CoinOne}
-                            alt="Dollar Coins"
+                            //alt="Dollar Coins"
                             className="inline-block align-middle w-12 h-12"
                             alt="1 Dollar Coin"
                           />
@@ -1236,7 +1236,7 @@ const CloseDayPage = () => {
                     <label>
                       <img
                         src={CoinPenny}
-                        alt="Pennies"
+                        //alt="Pennies"
                         className="inline-block align-middle w-12 h-12"
                         alt="Penny Coin"
                       />
@@ -1268,7 +1268,7 @@ const CloseDayPage = () => {
                       <label>
                         <img
                           src={BillTwo}
-                          alt="2's"
+                          //alt="2's"
                           className="inline-block align-middle w-12 h-12"
                           alt="2 Dollar Bill"
                         />
@@ -1301,7 +1301,7 @@ const CloseDayPage = () => {
                       <label>
                         <img
                           src={CoinHalf}
-                          alt="Half Dollar Coins"
+                          //alt="Half Dollar Coins"
                           className="inline-block align-middle w-12 h-12"
                           alt="Half Dollar Coin"
                         />

--- a/src/components/FundsTransferPage.jsx
+++ b/src/components/FundsTransferPage.jsx
@@ -756,7 +756,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="hundred_input">
                       <img
                         src={BillHundred}
-                        alt="100's"
+                        //alt="100's"
                         className="inline-block align-middle w-12 h-12"
                         alt="Hundred Dollar Bill"
                       />
@@ -789,7 +789,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="quarterRoll_input">
                       <img
                         src={RollQuarter}
-                        alt="Quarter Rolls"
+                        //alt="Quarter Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Quarter Roll"
                       />
@@ -822,7 +822,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="quarter_input">
                       <img
                         src={CoinQuarter}
-                        alt="Quarters"
+                        //alt="Quarters"
                         className="inline-block align-middle w-12 h-12"
                         alt="Quarter Coin"
                       />
@@ -857,7 +857,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="fifty_input">
                       <img
                         src={BillFifty}
-                        alt="50's"
+                        //alt="50's"
                         className="inline-block align-middle w-12 h-12"
                         alt="Fifty Dollar Bill"
                       />
@@ -890,7 +890,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="dimeRoll_input">
                       <img
                         src={RollDime}
-                        alt="Dime Rolls"
+                        //alt="Dime Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Dime Roll"
                       />
@@ -923,7 +923,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="dime_input">
                       <img
                         src={CoinDime}
-                        alt="Dimes"
+                        //alt="Dimes"
                         className="inline-block align-middle w-12 h-12"
                         alt="Dime Coin"
                       />
@@ -958,7 +958,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="twenty_input">
                       <img
                         src={BillTwenty}
-                        alt="20's"
+                        //alt="20's"
                         className="inline-block align-middle w-12 h-12"
                         alt="Twenty Dollar Bill"
                       />
@@ -991,7 +991,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="nickelRoll_input">
                       <img
                         src={RollNickel}
-                        alt="Nickel Rolls"
+                        //alt="Nickel Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Nickel Roll"
                       />
@@ -1024,7 +1024,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="nickel_input">
                       <img
                         src={CoinNickel}
-                        alt="Nickels"
+                        //alt="Nickels"
                         className="inline-block align-middle w-12 h-12"
                         alt="Nickel Coin"
                       />
@@ -1059,7 +1059,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="ten_input">
                       <img
                         src={BillTen}
-                        alt="10's"
+                        //alt="10's"
                         className="inline-block align-middle w-12 h-12"
                         alt="Ten Dollar Bill"
                       />
@@ -1092,7 +1092,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="pennyRoll_input">
                       <img
                         src={RollPenny}
-                        alt="Penny Rolls"
+                        //alt="Penny Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Penny Roll"
                       />
@@ -1125,7 +1125,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="penny_input">
                       <img
                         src={CoinPenny}
-                        alt="Pennies"
+                        //alt="Pennies"
                         className="inline-block align-middle w-12 h-12"
                         alt="Penny Coin"
                       />
@@ -1160,7 +1160,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="five_input">
                       <img
                         src={BillFive}
-                        alt="5's"
+                        //alt="5's"
                         className="inline-block align-middle w-12 h-12"
                         alt="Five Dollar Bill"
                       />
@@ -1195,7 +1195,7 @@ const FundsTransferPage = () => {
                         <label htmlFor="oneCoin_input">
                           <img
                             src={CoinOne}
-                            alt="Dollar Coins"
+                            //alt="Dollar Coins"
                             className="inline-block align-middle w-12 h-12"
                             alt="One Dollar Coin"
                           />
@@ -1227,7 +1227,7 @@ const FundsTransferPage = () => {
                         <label htmlFor="">
                           <img
                             src={BillTwo}
-                            alt="2's"
+                            //alt="2's"
                             className="inline-block align-middle w-12 h-12"
                             alt="Two Dollar Bill"
                           />
@@ -1264,7 +1264,7 @@ const FundsTransferPage = () => {
                     <label htmlFor="one_input">
                       <img
                         src={BillOne}
-                        alt="1's"
+                        //alt="1's"
                         className="inline-block align-middle w-12 h-12"
                         alt="One Dollar Bill"
                       />
@@ -1299,7 +1299,7 @@ const FundsTransferPage = () => {
                         <label htmlFor="halfDollar_input">
                           <img
                             src={CoinHalf}
-                            alt="Half Dollar Coins"
+                            //alt="Half Dollar Coins"
                             className="inline-block align-middle w-12 h-12"
                             alt="Half Dollar Coin"
                           />

--- a/src/components/OpenDay.jsx
+++ b/src/components/OpenDay.jsx
@@ -507,7 +507,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={BillHundred}
-                        alt="100's"
+                        //alt="100's"
                         className="inline-block align-middle w-12 h-12"
                         alt="100 Dollar Bill"
                       />
@@ -528,7 +528,7 @@ const OpenDayPage = () => {
                       value={elm100Dollar}
                       onChange={(e) => setElm100Dollar(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -537,7 +537,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={RollQuarter}
-                        alt="Quarter Rolls"
+                        //alt="Quarter Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Quarter Roll"
                       />
@@ -560,7 +560,7 @@ const OpenDayPage = () => {
                         setElmQuartersRolled(clamp(e.target.value))
                       }
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -571,7 +571,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={BillFifty}
-                        alt="50's"
+                        //alt="50's"
                         className="inline-block align-middle w-12 h-12"
                         alt="50 Dollar Bill"
                       />
@@ -592,7 +592,7 @@ const OpenDayPage = () => {
                       value={elm50Dollar}
                       onChange={(e) => setElm50Dollar(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -601,7 +601,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={RollDime}
-                        alt="Dime Rolls"
+                        //alt="Dime Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Dime Roll"
                       />
@@ -622,7 +622,7 @@ const OpenDayPage = () => {
                       value={elmDimesRolled}
                       onChange={(e) => setElmDimesRolled(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -633,7 +633,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={BillTwenty}
-                        alt="20's"
+                        //alt="20's"
                         className="inline-block align-middle w-12 h-12"
                         alt="20 Dollar Bill"
                       />
@@ -654,7 +654,7 @@ const OpenDayPage = () => {
                       value={elm20Dollar}
                       onChange={(e) => setElm20Dollar(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -663,7 +663,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={RollNickel}
-                        alt="Nickel Rolls"
+                        //alt="Nickel Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Nickel Roll"
                       />
@@ -686,7 +686,7 @@ const OpenDayPage = () => {
                         setElmNicklesRolled(clamp(e.target.value))
                       }
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -697,7 +697,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={BillTen}
-                        alt="10's"
+                        //alt="10's"
                         className="inline-block align-middle w-12 h-12"
                         alt="10 Dollar Bill"
                       />
@@ -718,7 +718,7 @@ const OpenDayPage = () => {
                       value={elm10Dollar}
                       onChange={(e) => setElm10Dollar(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -727,7 +727,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={RollPenny}
-                        alt="Penny Rolls"
+                        //alt="Penny Rolls"
                         className="inline-block align-middle w-12 h-12"
                         alt="Penny Roll"
                       />
@@ -750,7 +750,7 @@ const OpenDayPage = () => {
                         setElmPenniesRolled(clamp(e.target.value))
                       }
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -761,7 +761,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={BillFive}
-                        alt="5's"
+                        //alt="5's"
                         className="inline-block align-middle w-12 h-12"
                         alt="5 Dollar Bill"
                       />
@@ -782,7 +782,7 @@ const OpenDayPage = () => {
                       value={elm5Dollar}
                       onChange={(e) => setElm5Dollar(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -791,7 +791,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={CoinQuarter}
-                        alt="Quarters"
+                        //alt="Quarters"
                         className="inline-block align-middle w-12 h-12"
                         alt="Quarter Coin"
                       />
@@ -812,7 +812,7 @@ const OpenDayPage = () => {
                       value={elmQuarters}
                       onChange={(e) => setElmQuarters(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -823,7 +823,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={BillOne}
-                        alt="1's"
+                        //alt="1's"
                         className="inline-block align-middle w-12 h-12"
                         alt="1 Dollar Bill"
                       />
@@ -844,7 +844,7 @@ const OpenDayPage = () => {
                       value={elm1Dollar}
                       onChange={(e) => setElm1Dollar(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -853,7 +853,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={CoinDime}
-                        alt="Dimes"
+                        //alt="Dimes"
                         className="inline-block align-middle w-12 h-12"
                         alt="Dime Coin"
                       />
@@ -874,7 +874,7 @@ const OpenDayPage = () => {
                       value={elmDimes}
                       onChange={(e) => setElmDimes(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -898,7 +898,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={CoinNickel}
-                        alt="Nickels"
+                        //alt="Nickels"
                         className="inline-block align-middle w-12 h-12"
                         alt="Nickel Coin"
                       />
@@ -919,7 +919,7 @@ const OpenDayPage = () => {
                       value={elmNickles}
                       onChange={(e) => setElmNickles(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -932,7 +932,7 @@ const OpenDayPage = () => {
                         <label>
                           <img
                             src={CoinOne}
-                            alt="Dollar Coins"
+                            //alt="Dollar Coins"
                             className="inline-block align-middle w-12 h-12"
                             alt="1 Dollar Coin"
                           />
@@ -955,7 +955,7 @@ const OpenDayPage = () => {
                             setElm1DollarCoin(clamp(e.target.value))
                           }
                           min="0"
-                          className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                          className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                           type="number"
                           disabled={IsFirstPos}
                         />
@@ -972,7 +972,7 @@ const OpenDayPage = () => {
                     <label>
                       <img
                         src={CoinPenny}
-                        alt="Pennies"
+                        //alt="Pennies"
                         className="inline-block align-middle w-12 h-12"
                         alt="Penny Coin"
                       />
@@ -993,7 +993,7 @@ const OpenDayPage = () => {
                       value={elmPennies}
                       onChange={(e) => setElmPennies(clamp(e.target.value))}
                       min="0"
-                      className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                      className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                       type="number"
                       disabled={IsFirstPos}
                     />
@@ -1005,7 +1005,7 @@ const OpenDayPage = () => {
                       <label>
                         <img
                           src={BillTwo}
-                          alt="2's"
+                          //alt="2's"
                           className="inline-block align-middle w-12 h-12"
                           alt="2 Dollar Bill"
                         />
@@ -1026,7 +1026,7 @@ const OpenDayPage = () => {
                         value={elm2Dollar}
                         onChange={(e) => setElm2Dollar(clamp(e.target.value))}
                         min="0"
-                        className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                        className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                         type="number"
                         disabled={IsFirstPos}
                       />
@@ -1039,7 +1039,7 @@ const OpenDayPage = () => {
                       <label>
                         <img
                           src={CoinHalf}
-                          alt="Half Dollar Coins"
+                          //alt="Half Dollar Coins"
                           className="inline-block align-middle w-12 h-12"
                           alt="Half Dollar Coin"
                         />
@@ -1062,7 +1062,7 @@ const OpenDayPage = () => {
                           setElmHalfDollarCoin(clamp(e.target.value))
                         }
                         min="0"
-                        className="box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 hover:bg-nav-bg bg-white"
+                        className={`box-border text-center my-2 rounded-md ml-6 mr-12 w-24 float-right border-border-color border-2 ${IsFirstPos ? "bg-gray-300" : "hover:bg-nav-bg bg-white"}`}
                         type="number"
                         disabled={IsFirstPos}
                       />

--- a/src/components/SafeAudit.jsx
+++ b/src/components/SafeAudit.jsx
@@ -545,7 +545,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="hundred_input">
                         <img
                           src={BillHundred}
-                          alt="100's"
+                          //alt="100's"
                           className="inline-block align-middle w-12 h-12"
                           alt="100 Dollar Bill"
                         />
@@ -597,7 +597,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="quarterRoll_input">
                         <img
                           src={RollQuarter}
-                          alt="Quarter Rolls"
+                          //alt="Quarter Rolls"
                           className="inline-block align-middle w-12 h-12"
                           alt="Quarter Roll"
                         />
@@ -649,7 +649,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="quarter_input">
                         <img
                           src={CoinQuarter}
-                          alt="Quarters"
+                          //alt="Quarters"
                           className="inline-block align-middle w-12 h-12"
                           alt="Quarter Coin"
                         />
@@ -704,7 +704,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="fifty_input">
                         <img
                           src={BillFifty}
-                          alt="50's"
+                          //alt="50's"
                           className="inline-block align-middle w-12 h-12"
                           alt="50 Dollar Bill"
                         />
@@ -756,7 +756,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="dimeRoll_input">
                         <img
                           src={RollDime}
-                          alt="Dime Rolls"
+                          //alt="Dime Rolls"
                           className="inline-block align-middle w-12 h-12"
                           alt="Dime Roll"
                         />
@@ -808,7 +808,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="dime_input">
                         <img
                           src={CoinDime}
-                          alt="Dimes"
+                          //alt="Dimes"
                           className="inline-block align-middle w-12 h-12"
                           alt="Dime Coin"
                         />
@@ -863,7 +863,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="twenty_input">
                         <img
                           src={BillTwenty}
-                          alt="20's"
+                          //alt="20's"
                           className="inline-block align-middle w-12 h-12"
                           alt="20 Dollar Bill"
                         />
@@ -915,7 +915,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="nickelRoll_input">
                         <img
                           src={RollNickel}
-                          alt="Nickel Rolls"
+                          //alt="Nickel Rolls"
                           className="inline-block align-middle w-12 h-12"
                           alt="Nickel Roll"
                         />
@@ -967,7 +967,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="nickel_input">
                         <img
                           src={CoinNickel}
-                          alt="Nickels"
+                          //alt="Nickels"
                           className="inline-block align-middle w-12 h-12"
                           alt="Nickel Coin"
                         />
@@ -1022,7 +1022,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="ten_input">
                         <img
                           src={BillTen}
-                          alt="10's"
+                          //alt="10's"
                           className="inline-block align-middle w-12 h-12"
                           alt="10 Dollar Bill"
                         />
@@ -1074,7 +1074,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="pennyRoll_input">
                         <img
                           src={RollPenny}
-                          alt="Penny Rolls"
+                          //alt="Penny Rolls"
                           className="inline-block align-middle w-12 h-12"
                           alt="Penny Roll"
                         />
@@ -1126,7 +1126,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="penny_input">
                         <img
                           src={CoinPenny}
-                          alt="Pennies"
+                          //alt="Pennies"
                           className="inline-block align-middle w-12 h-12"
                           alt="Penny Coin"
                         />
@@ -1181,7 +1181,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="five_input">
                         <img
                           src={BillFive}
-                          alt="5's"
+                          //alt="5's"
                           className="inline-block align-middle w-12 h-12"
                           alt="5 Dollar Bill"
                         />
@@ -1235,7 +1235,7 @@ const SafeAuditPage = () => {
                           <label htmlFor="oneCoin_input">
                             <img
                               src={CoinOne}
-                              alt="Dollar Coins"
+                              //alt="Dollar Coins"
                               className="inline-block align-middle w-12 h-12"
                               alt="Dollar Coin"
                             />
@@ -1287,7 +1287,7 @@ const SafeAuditPage = () => {
                           <label htmlFor="">
                             <img
                               src={BillTwo}
-                              alt="2's"
+                              //alt="2's"
                               className="inline-block align-middle w-12 h-12"
                               alt="2 Dollar Bill"
                             />
@@ -1344,7 +1344,7 @@ const SafeAuditPage = () => {
                       <label htmlFor="one_input">
                         <img
                           src={BillOne}
-                          alt="1's"
+                          //alt="1's"
                           className="inline-block align-middle w-12 h-12"
                           alt="1 Dollar Bill"
                         />
@@ -1398,7 +1398,7 @@ const SafeAuditPage = () => {
                           <label htmlFor="halfDollar_input">
                             <img
                               src={CoinHalf}
-                              alt="Half Dollar Coins"
+                              //alt="Half Dollar Coins"
                               className="inline-block align-middle w-12 h-12"
                               alt="Half Dollar Coin"
                             />


### PR DESCRIPTION
- input boxes styling on openday are now shown to be disabled when a store performs its very first open day. Previously it looked like it was still enabled when it wasn't
- removed redundant alt tags on images for openday, closeday, safe audit, and funds transfer